### PR TITLE
Split README into website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,12 @@
-# GH2 🚀
+# gh2
 
-## ASCII Art Renderer for Python 🎨
-Python class to generate and render ASCII art using a grid of characters (glyphs)
+A creative coding language for ASCII art and poetic form.
 
-## Features 🔮
-- Customizable Margins: Adjust top, bottom, and left margins for the generated art
-- Glyph Placement: Place specific characters at coordinates within grid to form artwork
-- Rendering: Stores art into string or prints to console based on margins and gylphs provided
+## Resources 📚
 
-## Installation 🛠️
-To add to an existing project:
-1. Clone repository into project directory `git clone https://github.com/gh2hq/gh2.git`
-2. Install `npm install -e path/to/gh2`
-3. All done!
+- Documentation - https://gh2.dev/
+- Online Eidtor - https://editor.gh2.dev/
 
-## Usage 🎯
-```python3
-import gh2 
-poem = gh2.poem()
-poem.margin(top=0, bottom=0) #set margins for output (optional)
+## License 📄
 
-message = "I'm diagonal!" #message we want to display
-for i, letter in enumerate(message): #iterate through message
-    x,y=i,i
-    poem.point(x,y,letter) #plots gylph on coordinate plane at (x,y)
-poem.print() #print to console
-
-'''
-Or, conversely if you want to store as string and then print:
-poem_as_string = poem.content() # store as string
-print(poem_as_string)
-'''
-```
-### Terminal Output 💻:
-```
-I            
- '           
-  m          
-             
-    d        
-     i       
-      a      
-       g     
-        o    
-         n   
-          a  
-           l 
-            !
-```
-## Classes 📚
-``_Poem``
-The main class for creating and generating ASCII art (essentially the canvas)
-- ``__init__()``: Initializes ASCII art object with empty list of glyphs and default margin values (0)
-- ``margin(left=0, top=0, bottom=0)`` Sets margins for grid
-- ``point(i,j,ch)`` Adds character to coordinates (i,j) on grid
-- ``content()`` Returns gylphs and grid information into string
-- ``print()`` Print ASCII art to console
+ISC@Bairui SU

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,13 +14,17 @@ export default defineConfig({
   themeConfig: {
     logo: "/icon.svg",
     // https://vitepress.dev/reference/default-theme-config
-    nav: [{text: "Examples", link: "/examples"}],
+    nav: [
+      {text: "Examples", link: "/examples"},
+      {text: "Editor", link: "https://editor.gh2.dev/"},
+    ],
     sidebar: [
       {
         text: "Introduction",
         items: [
           {text: "What is gh2?", link: "/what-is-gh2"},
           {text: "Get Started", link: "/get-started"},
+          {text: "API Index", link: "/api-index"},
         ],
       },
       {
@@ -31,8 +35,9 @@ export default defineConfig({
     ],
     socialLinks: [{icon: "github", link: "https://github.com/gh2hq/gh2"}],
     footer: {
-      message: "Library released under <a style='text-decoration:underline;' href='https://github.com/gh2hq/gh2/blob/main/LICENSE'>ISC License</a>.",
-      copyright: `Copyright 2020–${new Date().getUTCFullYear()} Bairui Su.`
-    }
+      message:
+        "Library released under <a style='text-decoration:underline;' href='https://github.com/gh2hq/gh2/blob/main/LICENSE'>ISC License</a>.",
+      copyright: `Copyright 2020–${new Date().getUTCFullYear()} Bairui Su.`,
+    },
   },
 });

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -1,0 +1,7 @@
+# API Index
+
+- _gh_.**`poem()`**: Creates a goem for generating ASCII art (essentially the canvas).
+- _poem_.**`margin(left=0, top=0, bottom=0)`**: Sets margins for grid.
+- _poem_.**`point(i, j, ch)`**: Adds character to coordinates _(i,j)_ on grid.
+- _poem_.**`content()`**: Returns gylphs and grid information into string.
+- _poem_.**`print()`**: Prints ASCII art to console.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,1 +1,45 @@
 # Get Started
+
+## Try gh2 online
+
+You can try VitePress directly in your browser on gh's [Online Eidtor](https://editor.gh2.dev/).
+
+## Install from PyPI 🛠️
+
+```sh
+$ pip install gh2
+```
+
+## Usage 🎯
+
+:::python
+
+```py
+import gh2 as gh
+
+poem = gh.poem()
+
+# Sets margins for output (optional).
+poem.margin(top=1, bottom=1)
+
+# The message we want to display.
+message = "Hello, gh2!"
+
+# Iterates through message.
+for i, letter in enumerate(message):
+    # Plots gylph on coordinate plane at (x, y).
+    poem.point(i, i, letter)
+
+# Prints to console.
+poem.print()
+```
+
+:::
+
+Or, conversely if you want to store as string and then print:
+
+```py
+# Stores as string.
+string = poem.content()
+print(string)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,12 +18,12 @@ hero:
       link: /what-is-gh2
 
 features:
-  - title: Feature A
-    details: Lorem ipsum dolor sit amet, consectetur adipiscing elit
-  - title: Feature B
-    details: Lorem ipsum dolor sit amet, consectetur adipiscing elit
-  - title: Feature C
-    details: Lorem ipsum dolor sit amet, consectetur adipiscing elit
+  - title: Customizable Margins
+    details: Adjust top, bottom, and left margins for the generated art
+  - title: Glyph Placement
+    details: Place specific characters at coordinates within grid to form artwork
+  - title: Rendering
+    details: Stores art into string or prints to console based on margins and gylphs provided
 ---
 
 <div id="hero-name">

--- a/docs/what-is-gh2.md
+++ b/docs/what-is-gh2.md
@@ -1,1 +1,12 @@
 # What is gh2?
+
+A creative coding language for ASCII art and poetic form.
+
+## Resources 📚
+
+- Documentation - https://gh2.dev/
+- Online Eidtor - https://editor.gh2.dev/
+
+## License 📄
+
+ISC@Bairui SU


### PR DESCRIPTION
@lucastemb 

As mentioned in [this PR](https://github.com/gh2hq/gh2/pull/155), I’ve moved and updated the content you added to GH2's official website.

- Move _Installation_, _Usage_ and _Terminal Output_ to `docs/get-started.md`. ([preview](https://e1042f7f.gh2-316.pages.dev/get-started))
- Move _Features_ to `docs/index.md`. ([preview](https://e1042f7f.gh2-316.pages.dev))
- Move _Classes_ to `docs/api-index.md`. ([preview](https://e1042f7f.gh2-316.pages.dev/api-index))
- Move others to `docs/what-is-gh2.md`. ([preview](https://e1042f7f.gh2-316.pages.dev/what-is-gh2))

Thanks again for your contribution!